### PR TITLE
feat: Integrate tach for architecture management

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,101 @@
+# Gemini Context: debug-dojo
+
+This document provides context for the `debug-dojo` project, a Python-based command-line tool designed to enhance the debugging workflow.
+
+## Project Overview
+
+`debug-dojo` is a powerful Python package that streamlines debugging directly from the terminal. It acts as a unified interface for popular debuggers like `debugpy`, `pudb`, `pdb`, and `ipdb`. The project leverages the `rich` library to provide syntax-highlighted code, pretty-printed objects, and improved tracebacks for a "zen debugging" experience.
+
+Key features include:
+
+- A CLI tool named `dojo` to run scripts or modules with a specified debugger.
+- In-code helper functions for setting breakpoints (`b()`), pretty-printing (`p()`), inspecting objects (`i()`), and comparing objects (`c()`).
+- Configuration via `pyproject.toml` or a local `dojo.toml` file.
+
+The project is structured as a standard Python package with its source code in the `src/debug_dojo` directory. It uses `typer` for the CLI, `poethepoet` as a task runner, and `uv` for dependency and environment management.
+
+## Building and Running
+
+The project uses `uv` for dependency management and `poethepoet` for running tasks.
+
+### 1. Installation
+
+To set up the development environment, install all dependencies using `uv`:
+
+```bash
+uv sync --locked --dev
+```
+
+### 2. Running Tests
+
+Tests are written with `pytest` and can be run using the `poe` task runner:
+
+```bash
+poe test
+```
+
+To generate a coverage report:
+
+```bash
+poe coverage
+```
+
+### 3. Running the CLI Locally
+
+The main entry point is the `dojo` command. You can run it via `uv run` to test local changes:
+
+```bash
+dojo --help
+dojo my_script.py
+```
+
+## Development Conventions
+
+The project enforces a strict set of development conventions through linting, formatting, and type-checking. These are primarily managed by `ruff` and `basedpyright`.
+
+### Key Commands
+
+All quality checks are defined as `poe` tasks in `pyproject.toml` and are run in CI.
+
+- **Linting:** Check for code style and errors with `ruff`.
+
+  ```bash
+  poe lint
+  ```
+
+- **Formatting:** Check code formatting with `ruff`.
+
+  ```bash
+  poe format
+  ```
+
+- **Auto-Fixing:** Automatically fix formatting and linting issues.
+
+  ```bash
+  poe fix
+  ```
+
+- **Type-Checking:** Run static type analysis with `basedpyright`.
+
+  ```bash
+  poe type-check
+  ```
+
+- **All Checks:** Run the full pre-commit suite.
+
+  ```bash
+  poe precommit
+  ```
+
+- **Testing:** Run tests with coverage reporting.
+
+  ```bash
+  poe test
+  poe coverage
+  ```
+
+- **Dependency Checking:** Ensure dependencies are as intended.
+
+  ```bash
+  poe dependencies
+  ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -2,6 +2,16 @@
 
 ::: debug_dojo
 
+## Dependency Graph
+
+---
+
+```mermaid
+--8<-- "docs/dependency_graph.mmd"
+```
+
+---
+
 ::: debug_dojo._installers
 
 ::: debug_dojo._compare

--- a/docs/dependency_graph.mmd
+++ b/docs/dependency_graph.mmd
@@ -1,0 +1,11 @@
+graph TD
+    src.debug_dojo._installers --> src.debug_dojo._compare
+    src.debug_dojo._installers --> src.debug_dojo._config_models
+    src.debug_dojo._cli --> src.debug_dojo._installers
+    src.debug_dojo._cli --> src.debug_dojo._config
+    src.debug_dojo._cli --> src.debug_dojo._config_models
+    src.debug_dojo._config --> src.debug_dojo._config_models
+    src.debug_dojo.install --> src.debug_dojo._config
+    src.debug_dojo.install --> src.debug_dojo._installers
+    src.debug_dojo._config_models
+    src.debug_dojo._compare

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -16,7 +16,12 @@ markdown_extensions:
       line_spans: __span
       linenums: true
       use_pygments: true
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: pymdownx.superfences.fence_code_format
+  - pymdownx.snippets
 nav:
   - Introduction: index.md
   - Configuration: configuration.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@
         "mkdocs-material>=9.6.17",
         "mkdocs-typer2>=0.1.5",
         "mkdocstrings-python>=1.17.0",
+        "pymdown-extensions>=10.16.1",
     ]
 
 
@@ -96,12 +97,16 @@
 
 [tool.poe.tasks]
 
-    coverage   = { cmd = "pytest --doctest-modules --verbose --cov --cov-report=xml", help = "Create test coverage report." }
-    format     = { cmd = "ruff format --diff --config=pyproject.toml", help = "Check code formatting using ruff." }
-    lint       = { cmd = "uv run ruff check --config=pyproject.toml", help = "Check code rules using ruff." }
-    precommit  = { cmd = "pre-commit run --all-files", help = "Run all code quality checks." }
-    test       = { cmd = "pytest", help = "Run tests using pytest." }
-    type-check = { cmd = "basedpyright src tests", help = "Check static typing using basedpyright." }
+    coverage         = { cmd = "pytest --doctest-modules --verbose --cov --cov-report=xml", help = "Create test coverage report." }
+    dependencies     = { cmd = "tach check", help = "Check dependency layers using tach." }
+    dependency-graph = { cmd = "tach show --mermaid -o docs/dependency_graph.mmd", help = "Generate the dependency graph." }
+    docs             = { cmd = "hap run mkdocs serve", help = "Spawn docs server." }
+    format           = { cmd = "ruff format --diff --config=pyproject.toml", help = "Check code formatting using ruff." }
+    lint             = { cmd = "uv run ruff check --config=pyproject.toml", help = "Check code rules using ruff." }
+    precommit        = { cmd = "pre-commit run --all-files", help = "Run all code quality checks." }
+    publish-docs     = { cmd = "mkdocs gh-deploy --force", help = "Publish the docs to GitHub Pages." }
+    test             = { cmd = "pytest", help = "Run tests using pytest." }
+    type-check       = { cmd = "basedpyright src tests", help = "Check static typing using basedpyright." }
 
     [tool.poe.tasks.code-quality]
         help        = "Run all code quality checks."
@@ -123,6 +128,7 @@
             { cmd = "rm -rf dist" },
             { cmd = "uv build" },
             { cmd = "uv publish" },
+            "publish-docs",
         ]
 
 [tool.docformatter]

--- a/tach.toml
+++ b/tach.toml
@@ -1,0 +1,42 @@
+exclude      = [ "**/*__pycache__", "**/*egg-info", "**/docs", "**/tests", "**/venv" ]
+interfaces   = [  ]
+source_roots = [ ".", "src" ]
+
+forbid_circular_dependencies = true
+ignore_type_checking_imports = false
+layers                       = [ "usage", "core", "tools" ]
+respect_gitignore            = true
+
+[[modules]]
+    depends_on = [  ]
+    layer      = "core"
+    path       = "src.debug_dojo._config_models"
+
+[[modules]]
+    depends_on = [ "src.debug_dojo._compare", "src.debug_dojo._config_models" ]
+    layer      = "core"
+    path       = "src.debug_dojo._installers"
+
+[[modules]]
+    depends_on = [
+        "src.debug_dojo._installers",
+        "src.debug_dojo._config",
+        "src.debug_dojo._config_models",
+    ]
+    layer = "usage"
+    path = "src.debug_dojo._cli"
+
+[[modules]]
+    depends_on = [ "src.debug_dojo._config_models" ]
+    layer      = "core"
+    path       = "src.debug_dojo._config"
+
+[[modules]]
+    depends_on = [ "src.debug_dojo._config", "src.debug_dojo._installers" ]
+    layer      = "usage"
+    path       = "src.debug_dojo.install"
+
+[[modules]]
+    depends_on = [  ]
+    layer      = "tools"
+    path       = "src.debug_dojo._compare"

--- a/uv.lock
+++ b/uv.lock
@@ -308,6 +308,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocs-typer2" },
     { name = "mkdocstrings-python" },
+    { name = "pymdown-extensions" },
 ]
 
 [package.metadata]
@@ -340,6 +341,7 @@ docs = [
     { name = "mkdocs-material", specifier = ">=9.6.17" },
     { name = "mkdocs-typer2", specifier = ">=0.1.5" },
     { name = "mkdocstrings-python", specifier = ">=1.17.0" },
+    { name = "pymdown-extensions", specifier = ">=10.16.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit introduces `tach` to enforce architectural boundaries and adds related documentation, including a dependency graph. It also updates the project configuration to support these changes.
