### PR TITLE
'all-debuggers' optional dependency

### DIFF
--- a/.github/workflows/python_tests.yaml
+++ b/.github/workflows/python_tests.yaml
@@ -1,5 +1,8 @@
 name: Package Tests
 
+env:
+  UV_NO_SYNC: true
+
 permissions:
   contents: read
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pip install debug-dojo
 For full debugger support, you might want to install optional dependencies:
 
 ```bash
-pip install "debug-dojo[all]"
+pip install "debug-dojo[all-debuggers]"
 ```
 
 ## 💻 CLI Usage

--- a/docs/index.md
+++ b/docs/index.md
@@ -91,6 +91,12 @@ Python package management tools.
 pip install debug-dojo
 ```
 
+For full debugger support, you might want to install optional dependencies:
+
+```bash
+pip install "debug-dojo[all-debuggers]"
+```
+
 You can also use `poetry` or `uv` to add it to your project:
 
 ``` console

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [project]
-    authors = [ { name = "bwrob", email = "bartosz.marcin.wroblewski@gmail.com" } ]
+    authors = [
+        { name = "bwrob", email = "bartosz.marcin.wroblewski@gmail.com" },
+    ]
     classifiers = [
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
@@ -13,21 +15,23 @@
     ]
     dependencies = [
         "dacite>=1.0.0",
-        "debugpy>=1.0.0",
-        "ipdb>=0.12.0",
-        "pudb>=2019.1",
         "rich>=10.0.0",
         "tomlkit>=0.7.0",
         "typer>=0.3.0",
     ]
     description = "🏣 debug dojo, a place for zen debugging"
-    keywords = [ "debugging", "inspection", "tools", "development" ]
+    keywords = [
+        "debugging",
+        "inspection",
+        "tools",
+        "development",
+    ]
     license = 'MIT'
-    license-files = [ 'LICENSE' ]
+    license-files = ['LICENSE']
     name = "debug-dojo"
     readme = "README.md"
     requires-python = ">=3.10,<3.15"
-    version = "0.6.0"
+    version = "0.7.0"
 
     [project.urls]
         Changelog     = "https://bwrob.github.io/debug-dojo/changelog/"
@@ -38,12 +42,20 @@
     [project.scripts]
         "dojo" = "debug_dojo._cli:main"
 
+    [project.optional-dependencies]
+        all-debuggers = [
+            "debugpy>=1.0.0",
+            "ipdb>=0.12.0",
+            "pudb>=2020.1",
+        ]
+
 
 [dependency-groups]
 
     dev = [
         "basedpyright>=1.31.2",
         "coverage>=7.10.4",
+        "debug-dojo[all-debuggers]",
         "diff-cover>=9.6.0",
         "poethepoet>=0.37.0",
         "pytest>=8.4.1",
@@ -61,9 +73,15 @@
         "mkdocstrings-python>=1.17.0",
         "pymdown-extensions>=10.16.1",
         "typst>=0.14.2",
-]
+    ]
 
 
 [tool.uv]
     package          = true
     required-version = ">=0.8.0"
+
+    [tool.uv.workspace]
+        members = ["."]
+
+    [tool.uv.sources]
+        debug-dojo = { workspace = true }

--- a/src/debug_dojo/_installers.py
+++ b/src/debug_dojo/_installers.py
@@ -31,6 +31,12 @@ from ._config_models import (
 BREAKPOINT_ENV_VAR = "PYTHONBREAKPOINT"
 IPDB_CONTEXT_SIZE = "IPDB_CONTEXT_SIZE"
 
+_NOT_INSTALLED = (
+    "[yellow]{name} is not installed."
+    "Please install it to use this debugger."
+    "Defaulting to standard debugger.[/yellow]"
+)
+
 
 def use_pdb(config: PdbConfig) -> None:
     """Set PDB as the default debugger.
@@ -50,7 +56,11 @@ def use_pudb(config: PudbConfig) -> None:
     Configures `sys.breakpointhook` to use `pudb.set_trace` and sets the
     `PYTHONBREAKPOINT` environment variable.
     """
-    import pudb  # pyright: ignore[reportMissingTypeStubs]
+    try:
+        import pudb  # pyright: ignore[reportMissingTypeStubs]
+    except ImportError:
+        rich_print(_NOT_INSTALLED.format(name="PuDB"))
+        return
 
     os.environ[BREAKPOINT_ENV_VAR] = config.set_trace_hook
     sys.breakpointhook = pudb.set_trace
@@ -62,7 +72,11 @@ def use_ipdb(config: IpdbConfig) -> None:
     Configures `sys.breakpointhook` to use `ipdb.set_trace`, sets the
     `PYTHONBREAKPOINT` environment variable, and configures `IPDB_CONTEXT_SIZE`.
     """
-    import ipdb  # pyright: ignore[reportMissingTypeStubs]
+    try:
+        import ipdb  # pyright: ignore[reportMissingTypeStubs]
+    except ImportError:
+        rich_print(_NOT_INSTALLED.format(name="IPDB"))
+        return
 
     os.environ[BREAKPOINT_ENV_VAR] = config.set_trace_hook
     os.environ[IPDB_CONTEXT_SIZE] = str(config.context_lines)
@@ -76,7 +90,11 @@ def use_debugpy(config: DebugpyConfig) -> None:
     `PYTHONBREAKPOINT` environment variable, and starts a debugpy server
     waiting for a client connection.
     """
-    import debugpy  # pyright: ignore[reportMissingTypeStubs]
+    try:
+        import debugpy  # pyright: ignore[reportMissingTypeStubs]
+    except ImportError:
+        rich_print(_NOT_INSTALLED.format(name="Debugpy"))
+        return
 
     os.environ[BREAKPOINT_ENV_VAR] = config.set_trace_hook
     sys.breakpointhook = debugpy.breakpoint

--- a/uv.lock
+++ b/uv.lock
@@ -302,22 +302,27 @@ wheels = [
 
 [[package]]
 name = "debug-dojo"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "dacite" },
-    { name = "debugpy" },
-    { name = "ipdb" },
-    { name = "pudb" },
     { name = "rich" },
     { name = "tomlkit" },
     { name = "typer" },
+]
+
+[package.optional-dependencies]
+all-debuggers = [
+    { name = "debugpy" },
+    { name = "ipdb" },
+    { name = "pudb" },
 ]
 
 [package.dev-dependencies]
 dev = [
     { name = "basedpyright" },
     { name = "coverage" },
+    { name = "debug-dojo", extra = ["all-debuggers"] },
     { name = "diff-cover" },
     { name = "poethepoet" },
     { name = "pytest" },
@@ -340,18 +345,20 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "dacite", specifier = ">=1.0.0" },
-    { name = "debugpy", specifier = ">=1.0.0" },
-    { name = "ipdb", specifier = ">=0.12.0" },
-    { name = "pudb", specifier = ">=2019.1" },
+    { name = "debugpy", marker = "extra == 'all-debuggers'", specifier = ">=1.0.0" },
+    { name = "ipdb", marker = "extra == 'all-debuggers'", specifier = ">=0.12.0" },
+    { name = "pudb", marker = "extra == 'all-debuggers'", specifier = ">=2020.1" },
     { name = "rich", specifier = ">=10.0.0" },
     { name = "tomlkit", specifier = ">=0.7.0" },
     { name = "typer", specifier = ">=0.3.0" },
 ]
+provides-extras = ["all-debuggers"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "basedpyright", specifier = ">=1.31.2" },
     { name = "coverage", specifier = ">=7.10.4" },
+    { name = "debug-dojo", extras = ["all-debuggers"], editable = "." },
     { name = "diff-cover", specifier = ">=9.6.0" },
     { name = "poethepoet", specifier = ">=0.37.0" },
     { name = "pytest", specifier = ">=8.4.1" },


### PR DESCRIPTION
Updated README and documentation to reflect the new optional dependency group 'all-debuggers' for installing all supported debuggers.
